### PR TITLE
Add dependency on libssl-dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 1. Install required packages:
 ```
 sudo apt install build-essential git cmake \
-    libspdlog-dev libconfig-dev \
+    libspdlog-dev libconfig-dev libssl-dev \
     libgstreamer1.0-dev libgstreamer-plugins-bad1.0-dev \
     gstreamer1.0-plugins-good gstreamer1.0-plugins-bad gstreamer1.0-plugins-ugly gstreamer1.0-nice
 ```


### PR DESCRIPTION
Can't build libwebsockets without it, and it is not installed by default on Ubuntu 20.04 at least, not sure about 20.10.